### PR TITLE
Restrict usable input numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Overview
 
-T-generator will create a T-total for any number **This might be inaccurate for numbers outside of a 9x9 grid**
+T-generator will create a T-total for any number on a 9x9 grid.
+**do not use any value that is outside of a 9x9 grid (1-90)**
 
 Please check the wiki (https://github.com/lightman210567/T-generator/wiki) for documentation

--- a/T-generator/T-generator/Program.cs
+++ b/T-generator/T-generator/Program.cs
@@ -6,11 +6,12 @@ namespace lightman210567.TGenerator
     {
         public static int TGenerate(int T) // requires a int value returned
         {
-            if (T < 1)
+            // The if statements check if the input number is in a 9x9 grid. 9x9 grids contain numbers 1-90
+            if (T < 1) // if T is less than 1 then throw an exception
             {
                 throw new ArgumentException($"Input number must be 1 or larger");
             } 
-            else if (T > 90)
+            else if (T > 90) // if T is more than 90 throw an exception
             {
                 throw new ArgumentException("Input number must be less than or equal to 90");
             }

--- a/T-generator/T-generator/Program.cs
+++ b/T-generator/T-generator/Program.cs
@@ -6,6 +6,15 @@ namespace lightman210567.TGenerator
     {
         public static int TGenerate(int T) // requires a int value returned
         {
+            if (T < 1)
+            {
+                throw new ArgumentException($"Input number must be 1 or larger");
+            } 
+            else if (T > 90)
+            {
+                throw new ArgumentException("Input number must be less than or equal to 90");
+            }
+
             int n = T; // sets the value n to the value of T. n is used for the term to term rule of T-totals
 
             int TTotal = (5 * n) - 63; // multiplies n by 5 then subtracts 63 to get the T-total


### PR DESCRIPTION
set the usable input numbers to be only numbers that are present in a 9x9 grid. This means that only the numbers 1-90 can be used.